### PR TITLE
fix: move react native to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "homepage": "https://github.com/thewei/react-native-css-loader#readme",
   "dependencies": {
-    "gulp-react-native-stylesheet-css": "^1.4.0",
+    "gulp-react-native-stylesheet-css": "^1.4.0"
+  },
+  "peerDependencies": {
     "react-native": "^0.11.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "gulp-react-native-stylesheet-css": "^1.4.0"
   },
   "peerDependencies": {
-    "react-native": "^0.11.4"
+    "react-native": "^0.18.1"
   }
 }


### PR DESCRIPTION
fixed "Error: Naming collision detected" for me
